### PR TITLE
Removed deleting not existing index

### DIFF
--- a/src/migrations/m160711_132535_delete_foregin_key_from_values.php
+++ b/src/migrations/m160711_132535_delete_foregin_key_from_values.php
@@ -10,18 +10,8 @@ class m160711_132535_delete_foregin_key_from_values extends Migration
             'FK_Value_optionId',
             '{{%eav_attribute_value}}'
         );
-
-        $this->dropIndex(
-            'FK_Value_optionId',
-            '{{%eav_attribute_value}}'
-        );
         
         $this->dropForeignKey(
-            'FK_Value_entityId',
-            '{{%eav_attribute_value}}'
-        );
-
-        $this->dropIndex(
             'FK_Value_entityId',
             '{{%eav_attribute_value}}'
         );


### PR DESCRIPTION
I have problems with installing migrations.
```
Apply the above migrations? (yes|no) [no]:y
*** applying m150821_133232_init
    > create table {{%eav_entity}} ... done (time: 0.005s)
    > create table {{%eav_attribute}} ... done (time: 0.005s)
    > create table {{%eav_attribute_type}} ... done (time: 0.005s)
    > create table {{%eav_attribute_value}} ... done (time: 0.004s)
    > create table {{%eav_attribute_option}} ... done (time: 0.004s)
    > add foreign key FK_Attribute_typeId: {{%eav_attribute}} (typeId) references {{%eav_attribute_type}} (id) ... done (time: 0.002s)
    > add foreign key FK_EntityId: {{%eav_attribute}} (entityId) references {{%eav_entity}} (id) ... done (time: 0.001s)
    > add foreign key FK_Value_entityId: {{%eav_attribute_value}} (entityId) references {{%eav_entity}} (id) ... done (time: 0.001s)
    > add foreign key FK_Value_attributeId: {{%eav_attribute_value}} (attributeId) references {{%eav_attribute}} (id) ... done (time: 0.001s)
    > add foreign key FK_Value_optionId: {{%eav_attribute_value}} (optionId) references {{%eav_attribute_option}} (id) ... done (time: 0.001s)
    > add foreign key FK_Option_attributeId: {{%eav_attribute_option}} (attributeId) references {{%eav_attribute}} (id) ... done (time: 0.001s)
    > insert into {{%eav_attribute_type}} ... done (time: 0.014s)
    > insert into {{%eav_attribute_type}} ... done (time: 0.000s)
    > insert into {{%eav_attribute_type}} ... done (time: 0.000s)
    > insert into {{%eav_attribute_type}} ... done (time: 0.000s)
    > insert into {{%eav_attribute_type}} ... done (time: 0.000s)
    > insert into {{%eav_attribute_type}} ... done (time: 0.000s)
*** applied m150821_133232_init (time: 0.058s)

*** applying m160501_014209_add_column_order_into_option
    > add column order integer(11) DEFAULT 0 to table {{%eav_attribute_option}} ... done (time: 0.001s)
*** applied m160501_014209_add_column_order_into_option (time: 0.012s)

*** applying m160501_124615_create_table_eav_attribute_rules
    > create table {{%eav_attribute_rules}} ... done (time: 0.007s)
    > add foreign key FK_Rules_attributeId: {{%eav_attribute_rules}} (attributeId) references {{%eav_attribute}} (id) ... done (time: 0.002s)
*** applied m160501_124615_create_table_eav_attribute_rules (time: 0.020s)

*** applying m160501_230535_add_columns_into_attribute_rules
    > add column required smallint(1) DEFAULT 0 to table {{%eav_attribute_rules}} ... done (time: 0.001s)
    > add column visible smallint(1) DEFAULT 0 to table {{%eav_attribute_rules}} ... done (time: 0.001s)
    > add column locked smallint(1) DEFAULT 0 to table {{%eav_attribute_rules}} ... done (time: 0.001s)
*** applied m160501_230535_add_columns_into_attribute_rules (time: 0.010s)

*** applying m160501_232516_add_new_field_types
    > insert into {{%eav_attribute_type}} ... done (time: 0.009s)
*** applied m160501_232516_add_new_field_types (time: 0.017s)

*** applying m160501_234949_remove_column_required_from_attribute
    > drop column required from table {{%eav_attribute}} ... done (time: 0.001s)
*** applied m160501_234949_remove_column_required_from_attribute (time: 0.010s)

*** applying m160711_132535_delete_foregin_key_from_values
    > drop foreign key FK_Value_optionId from table {{%eav_attribute_value}} ... done (time: 0.001s)
    > drop index FK_Value_optionId on {{%eav_attribute_value}} ...Exception 'yii\db\Exception' with message 'SQLSTATE[42704]: Undefined object: 7 ERROR:  index "FK_Value_optionId" does not exist
The SQL being executed was: DROP INDEX "FK_Value_optionId"'

in /usr/src/app/vendor/yiisoft/yii2/db/Schema.php:664

Error Info:
Array
(
    [0] => 42704
    [1] => 7
    [2] => ERROR:  index "FK_Value_optionId" does not exist
)

Stack trace:
#0 /usr/src/app/vendor/yiisoft/yii2/db/Command.php(1263): yii\db\Schema->convertException(Object(PDOException), 'DROP INDEX "FK_...')
#1 /usr/src/app/vendor/yiisoft/yii2/db/Command.php(1075): yii\db\Command->internalExecute('DROP INDEX "FK_...')
#2 /usr/src/app/vendor/yiisoft/yii2/db/Migration.php(507): yii\db\Command->execute()
#3 /usr/src/app/vendor/mirocow/yii2-eav/src/migrations/m160711_132535_delete_foregin_key_from_values.php(16): yii\db\Migration->dropIndex('FK_Value_option...', '{{%eav_attribut...')
#4 /usr/src/app/vendor/yiisoft/yii2/console/controllers/BaseMigrateController.php(725): m160711_132535_delete_foregin_key_from_values->up()
#5 /usr/src/app/vendor/yiisoft/yii2/console/controllers/BaseMigrateController.php(199): yii\console\controllers\BaseMigrateController->migrateUp('m160711_132535_...')
#6 [internal function]: yii\console\controllers\BaseMigrateController->actionUp(0)
```

Because index `FK_Value_optionId` not exist.